### PR TITLE
Add ls alias to list-sessions.

### DIFF
--- a/pymux/entry_points/run_pymux.py
+++ b/pymux/entry_points/run_pymux.py
@@ -76,7 +76,7 @@ def run():
     if a['standalone']:
         mux.run_standalone(true_color=true_color)
 
-    elif a['list-sessions'] or a['<command>'] == 'list-sessions':
+    elif a['list-sessions'] or a['<command>'] == 'list-sessions' or a['<command>'] == 'ls':
         for c in list_clients():
             print(c.socket_name)
 


### PR DESCRIPTION
I typically use `tmux ls` to see the list of sessions. This adds that behavior to pymux. 