### PR TITLE
Write crash reports to secure temporary file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,9 +162,9 @@ in the examples directory.
 What if it crashes?
 -------------------
 
-If for some reason pymux crashes, it will attempt to write a stack trace to
-``/tmp/pymux.crash``. It is possible that the user interface freezes. Please
-create a GitHub issue with this stack trace.
+If for some reason pymux crashes, it will attempt to write a stack trace to a
+file with a name like ``/tmp/pymux.crash-*``. It is possible that the user
+interface freezes. Please create a GitHub issue with this stack trace.
 
 
 Special thanks

--- a/pymux/main.py
+++ b/pymux/main.py
@@ -33,6 +33,7 @@ import os
 import signal
 import six
 import sys
+import tempfile
 import traceback
 import weakref
 
@@ -491,8 +492,11 @@ class Pymux(object):
             # When something bad happens, always dump the traceback.
             # (Otherwise, when running as a daemon, and stdout/stderr are not
             # available, it's hard to see what went wrong.)
-            with open('/tmp/pymux.crash', 'wb') as f:
-                f.write(traceback.format_exc().encode('utf-8'))
+            fd, path = tempfile.mkstemp(prefix='pymux.crash-')
+            logger.fatal(
+                'Pymux has crashed, dumping traceback to {0}'.format(path))
+            os.write(fd, traceback.format_exc().encode('utf-8'))
+            os.close(fd)
             raise
 
         # Clean up socket.
@@ -578,7 +582,7 @@ class _BufferMapping(BufferMapping):
 
     def current_name(self, cli):
         """
-        Name of te current buffer.
+        Name of the current buffer.
         """
         client_state = self.pymux.get_client_state(cli)
 


### PR DESCRIPTION
The would resolve #8 by using the `tempfile` module to securely create a temporary file to store the crash report in.