### PR TITLE
add support for process name discovery on Macs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,22 +137,6 @@ Some ideas:
 - Better autocompletion.
 
 
-About Mac OS X support
-----------------------
-
-Pymux should work perfectly on OS X, just like on Linux systems. There is one
-bug however: window names are not updated automatically according to the name
-of the process. It displays ``(noname)`` on OS X.
-
-The reason for this is that on Linux, it's very easy to get the process name.
-It works by reading the content of ``/proc/(process_group)/cmdline``.  On OS X,
-this appears to be a system call, named ``proc_pidinfo``. There is a library
-called ``psutil`` that has the required functionality, but it's written in C. I
-won't include that, we don't want to depend on modules that require
-compilation. But if someone could contribute something based on ctypes, that
-would be much appreciated.
-
-
 Configuring
 -----------
 

--- a/pymux/darwin.py
+++ b/pymux/darwin.py
@@ -1,0 +1,78 @@
+from ctypes import cdll, pointer, c_uint, c_ubyte, c_ulong
+from struct import pack
+
+# Current Values as of El Capitan
+
+# /usr/include/sys/sysctl.h
+CTL_KERN = 1
+KERN_PROC = 14
+KERN_PROC_PID = 1
+KERN_PROC_PGRP = 2
+
+# /usr/include/sys/param.h
+MAXCOMLEN = 16
+
+# kinfo_proc (/usr/include/sys/sysctl.h)
+#  \-> extern_proc (/usr/include/sys/proc.h)
+P_COMM_OFFSET = 243
+
+# Finding the type for PIDs was *interesting*
+# pid_t in /usr/include/sys/types.h -> \
+#   pid_t in /usr/include/sys/_types/_pid_t.h -> \
+#   __darwin_pid_t -> /usr/include/sys/_types.h -> \
+#   __int32_t
+
+LIBC = None
+
+def init():
+    """
+    initialize ctypes DLL link
+    """
+    global LIBC
+
+    if LIBC is None:
+        LIBC = cdll.LoadLibrary('libc.dylib')
+
+def get_proc_info(pid):
+    """
+    use sysctl to retrieve process info
+    """
+    # ensure that we have the DLL loaded
+    init()
+
+    # request the length of the process data
+    mib = (c_uint * 4)(CTL_KERN, KERN_PROC, KERN_PROC_PID, pid)
+    oldlen = c_ulong()
+    oldlenp = pointer(oldlen)
+    r = LIBC.sysctl(mib, len(mib), None, oldlenp, None, 0)
+    if r:
+        return
+
+    # request the process data
+    reslen = oldlen.value
+    old = (c_ubyte * reslen)()
+    oldp = pointer(old)
+    r = LIBC.sysctl(mib, len(mib), old, oldlenp, None, 0)
+    if r:
+        return
+    #assert oldlen.value <= reslen
+
+    return old[:reslen]
+
+
+def get_proc_name(pid):
+    """
+    use sysctl to retrive process name
+    """
+    proc_kinfo = get_proc_info(pid)
+    if not proc_kinfo:
+        return
+
+    p_comm_range = proc_kinfo[P_COMM_OFFSET:P_COMM_OFFSET+MAXCOMLEN+1]
+    p_comm_raw = ''.join(chr(c) for c in p_comm_range)
+    p_comm = p_comm_raw.split('\0', 1)[0]
+
+    return p_comm
+
+__all__ = ['get_proc_info', 'get_proc_name']
+

--- a/pymux/process.py
+++ b/pymux/process.py
@@ -409,11 +409,11 @@ def get_cwd_for_pid(pid):
             pass
 
 
-def get_name_for_fd(fd):
-    """
-    Return the process name for a given process ID.
-    """
-    if sys.platform in ('linux', 'linux2'):
+if sys.platform in ('linux', 'linux2'):
+    def get_name_for_fd(fd):
+        """
+        Return the process name for a given process ID.
+        """
         pgrp = os.tcgetpgrp(fd)
 
         try:
@@ -421,3 +421,22 @@ def get_name_for_fd(fd):
                 return f.read().decode('utf-8', 'ignore').split('\0')[0]
         except IOError:
             pass
+elif sys.platform == 'darwin':
+    from .darwin import get_proc_name
+
+    def get_name_for_fd(fd):
+        """
+        Return the process name for a given process ID.
+        """
+        pgrp = os.tcgetpgrp(fd)
+
+        try:
+            return get_proc_name(pgrp)
+        except IOError:
+            pass
+else:
+    def get_name_for_fd(fd):
+        """
+        Return the process name for a given process ID.
+        """
+        return


### PR DESCRIPTION
This works on El Capitan.  I don't really have resources to test this across many Mac versions, but it appears to at least work.