### PR TITLE
Use gettempdir() for sockets

### DIFF
--- a/pymux/client.py
+++ b/pymux/client.py
@@ -14,6 +14,7 @@ import os
 import signal
 import socket
 import sys
+import tempfile
 
 
 __all__ = (
@@ -166,7 +167,8 @@ def list_clients():
     """
     List all the servers that are running.
     """
-    for path in glob.glob('/tmp/pymux.sock.%s.*' % getpass.getuser()):
+    p = '%s/pymux.sock.%s.*' % (tempfile.gettempdir(), getpass.getuser())
+    for path in glob.glob(p):
         try:
             yield Client(path)
         except socket.error:

--- a/pymux/entry_points/run_pymux.py
+++ b/pymux/entry_points/run_pymux.py
@@ -34,6 +34,7 @@ import getpass
 import logging
 import os
 import sys
+import tempfile
 
 __all__ = (
     'run',
@@ -56,7 +57,8 @@ def run():
 
     # Expand socket name. (Make it possible to just accept numbers.)
     if socket_name and socket_name.isdigit():
-        socket_name = '/tmp/pymux.sock.%s.%s' % (getpass.getuser(), socket_name)
+        socket_name = '%s/pymux.sock.%s.%s' % (
+            tempfile.gettempdir(), getpass.getuser(), socket_name)
 
     # Configuration filename.
     default_config = os.path.abspath(os.path.expanduser('~/.pymux.conf'))

--- a/pymux/server.py
+++ b/pymux/server.py
@@ -3,6 +3,7 @@ import getpass
 import json
 import socket
 import logging
+import tempfile
 
 from prompt_toolkit.layout.screen import Size
 from prompt_toolkit.terminal.vt100_input import InputStream
@@ -172,7 +173,8 @@ def bind_socket(socket_name=None):
         i = 0
         while True:
             try:
-                socket_name = '/tmp/pymux.sock.%s.%i' % (getpass.getuser(), i)
+                socket_name = '%s/pymux.sock.%s.%i' % (
+                    tempfile.gettempdir(), getpass.getuser(), i)
                 s.bind(socket_name)
                 return socket_name, s
             except (OSError, socket.error):


### PR DESCRIPTION
Change uses `tempfile.gettempdir()` for working with sockets, rather than hard-coding `/tmp`. This addresses #12 .