### PR TITLE
Fix module import

### DIFF
--- a/pymux/stream.py
+++ b/pymux/stream.py
@@ -4,7 +4,7 @@ Improvements on Pyte.
 from __future__ import unicode_literals
 from pyte.streams import Stream
 from pyte.escape import NEL
-from pyte import ctrl
+from pyte import control as ctrl
 from collections import defaultdict
 
 __all__ = (


### PR DESCRIPTION
When try run pymux cannot import ctrl module so this patch fix this.

```
Traceback (most recent call last):
  File "/usr/bin/pymux", line 9, in <module>
    load_entry_point('pymux==0.5', 'console_scripts', 'pymux')()
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 558, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 2682, in load_entry_point
    return ep.load()
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 2355, in load
    return self.resolve()
  File "/usr/lib64/python2.7/site-packages/pkg_resources/__init__.py", line 2361, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/lib64/python2.7/site-packages/pymux/entry_points/run_pymux.py", line 28, in <module>
    from pymux.main import Pymux
  File "/usr/lib64/python2.7/site-packages/pymux/main.py", line 18, in <module>
    from .arrangement import Arrangement, Pane, Window
  File "/usr/lib64/python2.7/site-packages/pymux/arrangement.py", line 11, in <module>
    from .process import Process
  File "/usr/lib64/python2.7/site-packages/pymux/process.py", line 13, in <module>
    from .stream import BetterStream
  File "/usr/lib64/python2.7/site-packages/pymux/stream.py", line 7, in <module>
    from pyte import ctrl
ImportError: cannot import name ctrl
```