### PR TITLE
Fix FreeBSD compatibilty on startup

### DIFF
--- a/pymux/utils.py
+++ b/pymux/utils.py
@@ -63,11 +63,13 @@ def pty_make_controlling_tty(tty_fd):
         os.close(fd)
 
     # Verify we now have a controlling tty.
-    fd = os.open("/dev/tty", os.O_WRONLY)
-    if fd < 0:
-        raise Exception("Could not open controlling tty, /dev/tty")
-    else:
-        os.close(fd)
+    if os.name != 'posix':
+        # skip this on BSD-like systems since it will break
+        fd = os.open("/dev/tty", os.O_WRONLY)
+        if fd < 0:
+            raise Exception("Could not open controlling tty, /dev/tty")
+        else:
+            os.close(fd)
 
 
 def daemonize(stdin='/dev/null', stdout='/dev/null', stderr='/dev/null'):


### PR DESCRIPTION
Fixes this error in BSD-like systems:
```python
	fd = os.open("/dev/tty", os.O_WRONLY)
	OSError: [Errno 6] Device not configured: '/dev/tty'
```

See also:

- https://github.com/saltstack/salt/blob/6537da7/salt/utils/vt.py#L535
- Fixes https://github.com/jonathanslenders/pymux/issues/33