### PR TITLE
Make sure sockets are not world readable

### DIFF
--- a/pymux/main.py
+++ b/pymux/main.py
@@ -456,7 +456,11 @@ class Pymux(object):
         Returns the socket name.
         """
         if self.socket is None:
+            # Py2 uses 0027 and Py3 uses 0o027, but both know
+            # how to create the right value from the string '0027'.
+            old_umask = os.umask(int('0027', 8))
             self.socket_name, self.socket = bind_socket(socket_name)
+            _ = os.umask(old_umask)
             self.socket.listen(0)
             self.eventloop.add_reader(self.socket.fileno(), self._socket_accept)
 


### PR DESCRIPTION
This pull request sets umask 0027 before calling `bind_socket()`, such that sockets are not world readable.
If applied, this will fix the last part of #12 so that the issue can be closed.

Since Python 2 uses the notation 0027 and Python 3 uses the notation 0o027, the correct value is created from the string '0027'.

