### PR TITLE
Updated syntax to work with Python 2.6

### DIFF
--- a/pymux/stream.py
+++ b/pymux/stream.py
@@ -139,7 +139,7 @@ class BetterStream(Stream):
 
             return defaultdict(
                 lambda: dummy,
-                {event: getattr(listener, attr) for event, attr in source_dict.items()})
+                dict((event, getattr(listener, attr)) for event, attr in source_dict.items()))
 
         basic_dispatch = create_dispatch_dictionary(basic)
         sharp_dispatch = create_dispatch_dictionary(sharp)


### PR DESCRIPTION
When I tried to use pymux with Python 2.6.6, I got the below error:

```
Traceback (most recent call last):
  File "/home/hkrishna/python/bin/pymux", line 8, in <module>
    load_entry_point('pymux==0.11', 'console_scripts', 'pymux')()
  File "/home/hkrishna/python/lib/python2.6/site-packages/setuptools-0.6c11-py2.6.egg/pkg_resources.py", line 318, in load_entry_point
  File "/home/hkrishna/python/lib/python2.6/site-packages/setuptools-0.6c11-py2.6.egg/pkg_resources.py", line 2221, in load_entry_point
  File "/home/hkrishna/python/lib/python2.6/site-packages/setuptools-0.6c11-py2.6.egg/pkg_resources.py", line 1954, in load
  File "/home/hkrishna/python/lib/python2.6/site-packages/pymux/entry_points/run_pymux.py", line 28, in <module>
    from pymux.main import Pymux
  File "/home/hkrishna/python/lib/python2.6/site-packages/pymux/main.py", line 17, in <module>
    from .arrangement import Arrangement, Pane, Window
  File "/home/hkrishna/python/lib/python2.6/site-packages/pymux/arrangement.py", line 11, in <module>
    from .process import Process
  File "/home/hkrishna/python/lib/python2.6/site-packages/pymux/process.py", line 13, in <module>
    from .stream import BetterStream
  File "/home/hkrishna/python/lib/python2.6/site-packages/pymux/stream.py", line 142
    {event: getattr(listener, attr) for event, attr in source_dict.items()})
                                      ^
SyntaxError: invalid syntax
```

The patch makes the failing line backwards compatible.